### PR TITLE
Accept only PNG, JPEG, JPG files

### DIFF
--- a/src/containers/NewBill.js
+++ b/src/containers/NewBill.js
@@ -19,15 +19,21 @@ export default class NewBill {
     const file = this.document.querySelector(`input[data-testid="file"]`).files[0]
     const filePath = e.target.value.split(/\\/g)
     const fileName = filePath[filePath.length-1]
-    this.firestore
-      .storage
-      .ref(`justificatifs/${fileName}`)
-      .put(file)
-      .then(snapshot => snapshot.ref.getDownloadURL())
-      .then(url => {
-        this.fileUrl = url
-        this.fileName = fileName
-      })
+    const fileExtension = fileName.split('.').pop();
+    if(['PNG', 'JPG', 'JPEG'].includes(fileExtension.toUpperCase())) { 
+      this.firestore
+        .storage
+        .ref(`justificatifs/${fileName}`)
+        .put(file)
+        .then(snapshot => snapshot.ref.getDownloadURL())
+        .then(url => {
+          this.fileUrl = url
+          this.fileName = fileName
+        })
+    } else {
+        document.querySelector(`input[data-testid="file"]`).value = "";
+        alert('Désolé, ' + file.name + ' est invalide, extensions autorisées jpeg/jpg/png')
+      }
   }
   handleSubmit = e => {
     e.preventDefault()

--- a/src/views/NewBillUI.js
+++ b/src/views/NewBillUI.js
@@ -55,7 +55,7 @@ export default () => {
                   </div>
                   <div class="col-half">
                     <label for="file" class="bold-label">Justificatif</label>
-                    <input required type="file" class="form-control blue-border" data-testid="file" />
+                    <input required type="file" class="form-control blue-border" accept="image/*" data-testid="file" />
                   </div>
                 </div>
             </div>

--- a/src/views/NewBillUI.js
+++ b/src/views/NewBillUI.js
@@ -55,7 +55,7 @@ export default () => {
                   </div>
                   <div class="col-half">
                     <label for="file" class="bold-label">Justificatif</label>
-                    <input required type="file" class="form-control blue-border" accept="image/*" data-testid="file" />
+                    <input required type="file" class="form-control blue-border" accept=".jpg, .jpeg, .png" data-testid="file" />
                   </div>
                 </div>
             </div>


### PR DESCRIPTION
## Description

Je suis connecté en tant qu'employé, je saisis une note de frais avec un justificatif qui a une extension différente de jpg, jpeg ou png, j'envoie. J'arrive sur la page Bills, je clique sur l'icône "voir" pour consulter le justificatif : la modale s'ouvre, mais il n'y a pas d'image. 

Si je me connecte à présent en tant qu'Admin, et que je clique sur le ticket correspondant, le nom du fichier affiché est null. De même, lorsque je clique sur l'icône "voir" pour consulter le justificatif : la modale s'ouvre, mais il n'y a pas d'image. 

## To-do

Comportements attendus :

- [x]  la modale doit afficher l'image.
- [x]  dans le dashboard, le formulaire correspondant au ticket doit afficher le nom du fichier.

Suggestion : empêcher la saisie d'un document qui a une extension différente de jpg, jpeg ou png au niveau du formulaire du fichier NewBill.js. Indice : cela se passe dans la méthode handleChangeFile...