### PR TITLE
Add test

### DIFF
--- a/src/__mocks__/firebase.js
+++ b/src/__mocks__/firebase.js
@@ -62,5 +62,11 @@ export default {
         "fileUrl": "https://firebasestorage.googleapis.com/v0/b/billable-677b6.a…f-1.jpg?alt=media&token=4df6ed2c-12c8-42a2-b013-346c1346f732"
       }]
     })
+  },
+
+  post: (data) => {
+    return Promise.resolve({
+      "id": "47qAXb6fIm2zOKkLzMro",
+    })
   }
 }

--- a/src/__tests__/Bills.js
+++ b/src/__tests__/Bills.js
@@ -3,6 +3,7 @@ import BillsUI from "../views/BillsUI.js"
 import { bills } from "../fixtures/bills.js"
 import Bills from "../containers/Bills.js"
 import { ROUTES } from "../constants/routes.js"
+import firebase from "../__mocks__/firebase"
 
 describe("Given I am connected as an employee", () => {
   describe("When I am on Bills Page", () => {
@@ -63,6 +64,34 @@ describe("Given I am connected as an employee", () => {
       fireEvent.click(btnNewBill)
 
       expect(mockFunction).toHaveBeenCalled()
+    })
+  })
+})
+describe("Given I am a user connected as Employee", () => {
+  describe("When I navigate to Bills page", () => {
+    test("fetches bills from mock API GET", async () => {
+      const getSpy = jest.spyOn(firebase, "get")
+      const bills = await firebase.get()
+      expect(getSpy).toHaveBeenCalledTimes(1)
+      expect(bills.data.length).toBe(4)
+    })
+    test("fetches bills from an API and fails with 404 message error", async () => {
+      firebase.get.mockImplementationOnce(() =>
+        Promise.reject(new Error("Erreur 404"))
+      )
+      const html = BillsUI({ error: "Erreur 404" })
+      document.body.innerHTML = html
+      const message = await screen.getByText(/Erreur 404/)
+      expect(message).toBeTruthy()
+    })
+    test("fetches messages from an API and fails with 500 message error", async () => {
+      firebase.get.mockImplementationOnce(() =>
+        Promise.reject(new Error("Erreur 500"))
+      )
+      const html = BillsUI({ error: "Erreur 500" })
+      document.body.innerHTML = html
+      const message = await screen.getByText(/Erreur 500/)
+      expect(message).toBeTruthy()
     })
   })
 })

--- a/src/__tests__/Bills.js
+++ b/src/__tests__/Bills.js
@@ -19,3 +19,21 @@ describe("Given I am connected as an employee", () => {
     })
   })
 })
+
+describe("Given an employee enter his email and his password", () => {
+  describe("When the inputs are wrong", () => {
+    test("Then error page appear", () => {
+      const html = BillsUI({ error: 'some error message' })
+      document.body.innerHTML = html
+      expect(screen.getAllByText('Erreur')).toBeTruthy()
+      expect(screen.getAllByText('some error message')).toBeTruthy()
+    })
+  })
+  describe("When the inputs are good", () => {
+    test("Then loading page appear", () => {
+      const html = BillsUI({ loading: true })
+      document.body.innerHTML = html
+      expect(screen.getAllByText('Loading...')).toBeTruthy()
+    })
+  })
+})

--- a/src/__tests__/Bills.js
+++ b/src/__tests__/Bills.js
@@ -1,6 +1,8 @@
-import { screen } from "@testing-library/dom"
+import { fireEvent, screen } from "@testing-library/dom"
 import BillsUI from "../views/BillsUI.js"
 import { bills } from "../fixtures/bills.js"
+import Bills from "../containers/Bills.js"
+import { ROUTES } from "../constants/routes.js"
 
 describe("Given I am connected as an employee", () => {
   describe("When I am on Bills Page", () => {
@@ -34,6 +36,33 @@ describe("Given an employee enter his email and his password", () => {
       const html = BillsUI({ loading: true })
       document.body.innerHTML = html
       expect(screen.getAllByText('Loading...')).toBeTruthy()
+    })
+  })
+})
+
+describe("Given I am connected as an employee", () => {
+  describe("When I click on button 'Nouvelle note de frais'", () => {
+    test("Then the page new bill appear", () => {
+      document.body.innerHTML = BillsUI(bills);
+
+      const onNavigate = (pathname) => {
+        document.body.innerHTML = ROUTES({ pathname })
+      }
+
+      const bill = new Bills({
+        document,
+        onNavigate,
+        firestore: null,
+        localStorage: window.localStorage
+      })
+
+      const btnNewBill = screen.getByTestId('btn-new-bill');
+      const mockFunction = jest.fn(bill.handleClickNewBill)
+
+      btnNewBill.addEventListener('click', mockFunction)
+      fireEvent.click(btnNewBill)
+
+      expect(mockFunction).toHaveBeenCalled()
     })
   })
 })

--- a/src/__tests__/Bills.js
+++ b/src/__tests__/Bills.js
@@ -67,6 +67,38 @@ describe("Given I am connected as an employee", () => {
     })
   })
 })
+
+describe("Given I am connected as an employee", () => {
+  describe("When I click on the eye icon", () => {
+    test("Then a modal should appear", () => {
+
+      const html = BillsUI({ data: bills });
+      document.body.innerHTML = html;
+
+      const onNavigate = (pathname) => {
+        document.body.innerHTML = ROUTES({ pathname });
+      };
+
+      const classBills = new Bills({
+        document,
+        onNavigate,
+        firestore: null,
+        localStorage: window.localStorage,
+      });
+
+      const iconEye = screen.getAllByTestId("icon-eye")[0];
+      const modal = document.getElementById("modaleFile");
+
+      const mockFunction = jest.fn(classBills.handleClickIconEye(iconEye))
+      iconEye.addEventListener("click", mockFunction);
+      fireEvent.click(iconEye);
+
+      expect(mockFunction).toHaveBeenCalled();
+      expect(modal).toBeTruthy();
+    })
+  })
+})
+
 describe("Given I am a user connected as Employee", () => {
   describe("When I navigate to Bills page", () => {
     test("fetches bills from mock API GET", async () => {

--- a/src/__tests__/Bills.js
+++ b/src/__tests__/Bills.js
@@ -44,7 +44,7 @@ describe("Given an employee enter his email and his password", () => {
 describe("Given I am connected as an employee", () => {
   describe("When I click on button 'Nouvelle note de frais'", () => {
     test("Then the page new bill appear", () => {
-      document.body.innerHTML = BillsUI(bills);
+      document.body.innerHTML = BillsUI({data : bills});
 
       const onNavigate = (pathname) => {
         document.body.innerHTML = ROUTES({ pathname })
@@ -88,6 +88,8 @@ describe("Given I am connected as an employee", () => {
 
       const iconEye = screen.getAllByTestId("icon-eye")[0];
       const modal = document.getElementById("modaleFile");
+
+      $.fn.modal = jest.fn()
 
       const mockFunction = jest.fn(classBills.handleClickIconEye(iconEye))
       iconEye.addEventListener("click", mockFunction);

--- a/src/__tests__/NewBill.js
+++ b/src/__tests__/NewBill.js
@@ -1,7 +1,6 @@
-import { screen } from "@testing-library/dom"
+import { fireEvent, screen } from "@testing-library/dom"
 import NewBillUI from "../views/NewBillUI.js"
 import NewBill from "../containers/NewBill.js"
-
 
 describe("Given I am connected as an employee", () => {
   describe("When I am on NewBill Page", () => {
@@ -9,6 +8,83 @@ describe("Given I am connected as an employee", () => {
       const html = NewBillUI()
       document.body.innerHTML = html
       //to-do write assertion
+    })
+  })
+})
+
+describe("Given I am connected as an employee", () => {
+  describe("When I fill input with good extension file", () => {
+    test("Then the file should be upload", () => {
+      document.body.innerHTML = NewBillUI();
+
+      const onNavigate = (pathname) => {
+        document.body.innerHTML = ROUTES({ pathname })
+      }
+
+      const newBill = new NewBill({
+        document,
+        onNavigate,
+        firestore: null,
+        localStorage: window.localStorage
+      })
+
+      const fileInput = screen.getByTestId("file");
+      const mockFunction = jest.fn(newBill.handleChangeFile)
+
+      fileInput.addEventListener('change', mockFunction)
+      fireEvent.change(fileInput, {
+        target: {
+          files: [new File([''], 'chucknorris.png', { type: 'image/png' })],
+        },
+      })
+      expect(mockFunction).toHaveBeenCalled()
+      expect(!fileInput.classList.contains('red-border')).toBeTruthy();
+
+      fileInput.addEventListener('change', mockFunction)
+      fireEvent.change(fileInput, {
+        target: {
+          files: [new File([''], 'chucknorris.jpeg', { type: 'image/jpeg' })],
+        },
+      })
+      expect(mockFunction).toHaveBeenCalled()
+      expect(!fileInput.classList.contains('red-border')).toBeTruthy();
+
+      fileInput.addEventListener('change', mockFunction)
+      fireEvent.change(fileInput, {
+        target: {
+          files: [new File([''], 'chucknorris.jpg', { type: 'image/jpg' })],
+        },
+      })
+      expect(mockFunction).toHaveBeenCalled()
+      expect(!fileInput.classList.contains('red-border')).toBeTruthy();
+    })
+  })
+  describe("When I fill input with wrong extension file", () => {
+    test("Then the file should not be upload", () => {
+      document.body.innerHTML = NewBillUI();
+
+      const onNavigate = (pathname) => {
+        document.body.innerHTML = ROUTES({ pathname })
+      }
+
+      const newBill = new NewBill({
+        document,
+        onNavigate,
+        firestore: null,
+        localStorage: window.localStorage
+      })
+
+      const fileInput = screen.getByTestId("file");
+
+      const mockFunction = jest.fn(newBill.handleChangeFile)
+      fileInput.addEventListener('change', mockFunction)
+      fireEvent.change(fileInput, {
+        target: {
+          files: [new File([''], 'chucknorris.gif', { type: 'image/gif' })],
+        },
+      })
+      expect(mockFunction).toHaveBeenCalled()
+      expect(fileInput.classList.contains('red-border')).toBeTruthy();
     })
   })
 })

--- a/src/__tests__/NewBill.js
+++ b/src/__tests__/NewBill.js
@@ -3,6 +3,7 @@ import NewBillUI from "../views/NewBillUI.js"
 import NewBill from "../containers/NewBill.js"
 import { localStorageMock } from "../__mocks__/localStorage.js"
 import { ROUTES } from "../constants/routes"
+import firebase from "../__mocks__/firebase"
 
 describe("Given I am connected as an employee", () => {
   describe("When I am on NewBill Page", () => {
@@ -119,6 +120,62 @@ describe("Given I am connected as an employee", () => {
       fireEvent.submit(form)
 
       expect(mockFunction).toHaveBeenCalled()
+    })
+  })
+})
+
+describe("Given I am a user connected as Employee", () => {
+  describe("When I fill new bill form", () => {
+    test("Fetches bill ID from mock API post", async() => {
+      const dataBill = {
+        email:  'test@test',
+        type: 'Restaurants et bars',
+        name:  '',
+        amount: 20,
+        date:  '2021-07-22',
+        vat: '',
+        pct: 20,
+        commentary: '',
+        fileUrl: '',
+        fileName: 'justificatif.png',
+      }
+
+      const postSpy = jest.spyOn(firebase, 'post')
+      const postBill = await firebase.post(dataBill)
+
+      expect(postSpy).toHaveBeenCalledTimes(1)
+      expect(postSpy).toReturn()
+
+      expect(postBill.id).toMatch("47qAXb6fIm2zOKkLzMro")
+
+      const getSpy = jest.spyOn(firebase, "get")
+      const bills = await firebase.get()
+      expect(getSpy).toHaveBeenCalledTimes(1)
+      expect(bills.data[0].id).toBe(postBill.id)
+    })
+  })
+  describe("When I click on submit button", () => {
+    test("Then the function handleSubmit should be called", () => {
+      document.body.innerHTML = NewBillUI();
+
+      const onNavigate = (pathname) => {
+        document.body.innerHTML = ROUTES({ pathname })
+      }
+
+      const newBill = new NewBill({
+        document,
+        onNavigate,
+        firestore: null,
+        localStorage: window.localStorage
+      })
+
+      const form = screen.getByTestId("form-new-bill");
+      const mockFunction = jest.fn(newBill.handleSubmit)
+
+      form.addEventListener('submit', mockFunction)
+      fireEvent.submit(form)
+
+    expect(mockFunction).toHaveBeenCalled()
     })
   })
 })

--- a/src/__tests__/NewBill.js
+++ b/src/__tests__/NewBill.js
@@ -1,6 +1,8 @@
 import { fireEvent, screen } from "@testing-library/dom"
 import NewBillUI from "../views/NewBillUI.js"
 import NewBill from "../containers/NewBill.js"
+import { localStorageMock } from "../__mocks__/localStorage.js"
+import { ROUTES } from "../constants/routes"
 
 describe("Given I am connected as an employee", () => {
   describe("When I am on NewBill Page", () => {
@@ -85,6 +87,38 @@ describe("Given I am connected as an employee", () => {
       })
       expect(mockFunction).toHaveBeenCalled()
       expect(fileInput.classList.contains('red-border')).toBeTruthy();
+    })
+  })
+})
+
+describe("Given I am connected as an employee", () => {
+  describe("When I click on submit button", () => {
+    test("Then the function handleSubmit should be called", () => {
+      document.body.innerHTML = NewBillUI();
+
+      const onNavigate = (pathname) => {
+        document.body.innerHTML = ROUTES({ pathname })
+      }
+
+      Object.defineProperty(window, 'localStorage', { value: localStorageMock })
+      window.localStorage.setItem('user', JSON.stringify({
+        email: 'test@test.com'
+      }))
+
+      const newBill = new NewBill({
+        document,
+        onNavigate,
+        firestore: null,
+        localStorage: window.localStorage
+      })
+
+      const form = screen.getByTestId("form-new-bill");
+      const mockFunction = jest.fn(newBill.handleSubmit)
+
+      form.addEventListener('submit', mockFunction)
+      fireEvent.submit(form)
+
+      expect(mockFunction).toHaveBeenCalled()
     })
   })
 })

--- a/src/app/format.js
+++ b/src/app/format.js
@@ -1,4 +1,7 @@
 export const formatDate = (dateStr) => {
+  if (!dateStr) {
+    return ''
+  }
   const date = new Date(dateStr)
   const ye = new Intl.DateTimeFormat('fr', { year: 'numeric' }).format(date)
   const mo = new Intl.DateTimeFormat('fr', { month: 'short' }).format(date)

--- a/src/containers/Bills.js
+++ b/src/containers/Bills.js
@@ -24,7 +24,7 @@ export default class {
     const billUrl = icon.getAttribute("data-bill-url")
     const imgWidth = Math.floor($('#modaleFile').width() * 0.5)
     $('#modaleFile').find(".modal-body").html(`<div style='text-align: center;'><img width=${imgWidth} src=${billUrl} /></div>`)
-    $('#modaleFile').modal('show')
+    if (typeof $('#modaleFile').modal === 'function') $('#modaleFile').modal('show')
   }
 
   // not need to cover this function by tests

--- a/src/containers/Bills.js
+++ b/src/containers/Bills.js
@@ -24,7 +24,7 @@ export default class {
     const billUrl = icon.getAttribute("data-bill-url")
     const imgWidth = Math.floor($('#modaleFile').width() * 0.5)
     $('#modaleFile').find(".modal-body").html(`<div style='text-align: center;'><img width=${imgWidth} src=${billUrl} /></div>`)
-    if (typeof $('#modaleFile').modal === 'function') $('#modaleFile').modal('show')
+    $('#modaleFile').modal('show')
   }
 
   // not need to cover this function by tests

--- a/src/containers/Dashboard.js
+++ b/src/containers/Dashboard.js
@@ -145,8 +145,8 @@ export default class {
       this.counter ++
     }
 
-    bills.forEach(bill => {
-      $(`#open-bill${bill.id}`).click((e) => this.handleEditTicket(e.stopImmediatePropagation(), bill, bills))
+    filteredBills(bills, getStatus(this.index)).forEach(bill => {
+      $(`#open-bill${bill.id}`).click((e) => this.handleEditTicket(e, bill, bills))
     })
 
     return bills

--- a/src/containers/NewBill.js
+++ b/src/containers/NewBill.js
@@ -16,22 +16,30 @@ export default class NewBill {
     new Logout({ document, localStorage, onNavigate })
   }
   handleChangeFile = e => {
+    const input = this.document.querySelector(`input[data-testid="file"]`)
     const file = this.document.querySelector(`input[data-testid="file"]`).files[0]
-    const filePath = e.target.value.split(/\\/g)
-    const fileName = filePath[filePath.length-1]
+    const fileName = file.name
     const fileExtension = fileName.split('.').pop();
-    if(['PNG', 'JPG', 'JPEG'].includes(fileExtension.toUpperCase())) { 
-      this.firestore
-        .storage
-        .ref(`justificatifs/${fileName}`)
-        .put(file)
-        .then(snapshot => snapshot.ref.getDownloadURL())
-        .then(url => {
-          this.fileUrl = url
-          this.fileName = fileName
-        })
+    if (['PNG', 'JPG', 'JPEG'].includes(fileExtension.toUpperCase())) {
+      if (input.classList.contains('red-border')) {
+        input.classList.remove('red-border')
+      }
+      if (this.firestore) {
+        this.firestore
+          .storage
+          .ref(`justificatifs/${fileName}`)
+          .put(file)
+          .then(snapshot => snapshot.ref.getDownloadURL())
+          .then(url => {
+            this.fileUrl = url
+            this.fileName = fileName
+          })
+      }
     } else {
-      this.document.querySelector(`input[data-testid="file"]`).value = "";
+      input.value = "";
+      if (!input.classList.contains('red-border')) {
+        input.classList.add('red-border')
+      }
     }
   }
   handleSubmit = e => {

--- a/src/css/newbill.css
+++ b/src/css/newbill.css
@@ -22,6 +22,13 @@
   border-radius: 5px;
 }
 
+.red-border {
+  opacity: 0.5;
+  border: 2px solid red !important;
+  box-sizing: border-box;
+  border-radius: 5px;
+}
+
 label {
   font-style: normal;
   font-weight: 500;


### PR DESCRIPTION
Le rapport de couverture de branche de Jest indique que le fichiers suivants ne sont pas couverts (cf. copie d'écran) :

- [x]  composant views/Bills : faire passer le taux de couverture à 100%
- [x]  composant container/Bills :
    - [x]  couvrir tous les "statements" sauf les appels au back-end firebase (ils sont signalés en commentaire dans le code) : c'est simple, il faut que [le rapport de couverture du fichier container/Bills](http://127.0.0.1:8080/coverage/lcov-report/containers/Bills.js.html) soit vert. Cela devrait permettre d'obtenir un taux de couverture aux alentours de 80% dans la colonne "statements".
    - [x]  ajouter un test d'intégration GET Bills. Tu peux t'inspirer celui qui est fait (signalé en commentaires) pour Dashboard.
- [ ]  composant container/NewBill :
    - [x]  couvrir tous les "statements" sauf les appels au back-end firebase (ils sont signalés en commentaire dans le code) : c'est simple, il faut que le rapport de couverture du fichier container/NewBill soit vert (accessible à [cette adresse](http://127.0.0.1:8080/coverage/lcov-report/containers/NewBill.js.html) quand tu auras lancé le serveur). Cela devrait permettre d'obtenir un taux de couverture aux alentours de 80% dans la colonne "statements".
    - [ ]  ajouter un test d'intégration POST new bill. Tu peux t'inspirer celui qui est fait (signalé en commentaires) pour Dashboard.

Respecter la structure des tests unitaires en place : Given  / When / Then avec le résultat attendu. Un exemple est donné dans le squelette du test __tests__/Bills.js